### PR TITLE
Fix primitive: Load & store float64 from bytes

### DIFF
--- a/smalltalksrc/Melchor/VMClass.class.st
+++ b/smalltalksrc/Melchor/VMClass.class.st
@@ -556,14 +556,16 @@ VMClass >> fetchSingleFloatAtPointer: pointer into: aFloat [
 
 { #category : #'memory access' }
 VMClass >> floatAtPointer: pointer [
+
 	<doNotGenerate>
-	self halt.
+	self notYetImplemented 
 ]
 
 { #category : #'memory access' }
 VMClass >> floatAtPointer: pointer put: value [
+
 	<doNotGenerate>
-	self halt.
+	self notYetImplemented
 ]
 
 { #category : #'C library simulation' }

--- a/smalltalksrc/VMMaker/SpurMemoryManager.class.st
+++ b/smalltalksrc/VMMaker/SpurMemoryManager.class.st
@@ -4988,6 +4988,17 @@ SpurMemoryManager >> firstFixedFieldOfMaybeImmediate: oop [
 		ifFalse: [self firstFixedField: oop]
 ]
 
+{ #category : #'object access' }
+SpurMemoryManager >> firstFloat64OfDataObject: objOop [
+	<returnTypeC: #'void *'>
+	<api>
+	<inline: true>
+	| fmt |
+	fmt := self formatOf: objOop.
+	fmt ~= 9 ifTrue: [ ^ 0 ].
+	^ self firstFixedField: objOop
+]
+
 { #category : #'object format' }
 SpurMemoryManager >> firstIndexableField: objOop [
 	"NOTE: overridden in various simulator subclasses to add coercion to CArray, so please duplicate any changes.

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -6475,6 +6475,18 @@ StackInterpreter >> floatArg: index [
 	^objectMemory floatValueOf: oop
 ]
 
+{ #category : #'memory access' }
+StackInterpreter >> floatAtPointer: anOop [
+
+	^ objectMemory float64At: anOop
+]
+
+{ #category : #'memory access' }
+StackInterpreter >> floatAtPointer: anOop put: value [
+
+	objectMemory float64At: anOop put: value
+]
+
 { #category : #'debug printing' }
 StackInterpreter >> flush [
 	<api>

--- a/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterPrimitives.class.st
@@ -2061,7 +2061,7 @@ StackInterpreterPrimitives >> primitiveLoadFloat64FromBytes [
 	 or: [argumentCount > 1]) ifTrue:
 		[^self primitiveFailFor: PrimErrBadArgument].
 	index := objectMemory integerValueOf: index.
-	bytes := objectMemory firstBytePointerOfDataObject: rcvr.
+	bytes := objectMemory firstFloat64OfDataObject: rcvr.
 	bytes == 0 ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
 
 	byteSize := objectMemory numBytesOf: rcvr.
@@ -3307,7 +3307,7 @@ StackInterpreterPrimitives >> primitiveStoreFloat64IntoBytes [
 		[^self primitiveFailFor: PrimErrBadArgument].
 	index := objectMemory integerValueOf: index.
 	value := objectMemory floatValueOf: valueObject.
-	bytes := objectMemory firstBytePointerOfDataObject: rcvr.
+	bytes := objectMemory firstFloat64OfDataObject: rcvr.
 	bytes == 0 ifTrue: [ ^ self primitiveFailFor: PrimErrBadArgument ].
 
 	byteSize := objectMemory numBytesOf: rcvr.

--- a/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
+++ b/smalltalksrc/VMMakerTests/VMPrimitiveTest.class.st
@@ -2322,6 +2322,23 @@ VMPrimitiveTest >> testPrimitiveLessThanWithNoErrorPopsOperands [
 	self assert: interpreter stackTop equals: (memory integerObjectOf: 42). 
 ]
 
+{ #category : #'tests - primitiveFloat64' }
+VMPrimitiveTest >> testPrimitiveLoadFloat64FromBytes [
+
+	| class array |
+	class := self newClassInOldSpaceWithSlots: 0 instSpec: (memory sixtyFourBitIndexableFormat).
+	array := memory instantiateClass: class indexableSize: 1.
+	memory storeFloat64: 0 ofObject: array withValue: 42.0.
+	
+	interpreter push: array.
+	interpreter push: (memory integerObjectOf: 0).
+	interpreter primitiveLoadFloat64FromBytes.
+	
+	self deny: interpreter failed.
+	self assert: (memory fetchFloat64: 0 ofObject: array) equals: 42.0.
+	self assert: interpreter stackTop equals: (memory floatObjectOf: 42.0). 
+]
+
 { #category : #'tests - primitiveMod' }
 VMPrimitiveTest >> testPrimitiveMod [
 
@@ -4474,6 +4491,23 @@ VMPrimitiveTest >> testPrimitiveSnapshotNewKeptObjectShouldBeTenured [
 	self
 		assert: (memory hashBitsOf: self keptObjectInVMVariable1)
 		equals: objectHash
+]
+
+{ #category : #'tests - primitiveFloat64' }
+VMPrimitiveTest >> testPrimitiveStoreFloat64IntoBytes [
+
+	| class array |
+	class := self newClassInOldSpaceWithSlots: 0 instSpec: (memory sixtyFourBitIndexableFormat).
+	array := memory instantiateClass: class indexableSize: 1.
+	
+	interpreter push: array.
+	interpreter push: (memory integerObjectOf: 0).
+	interpreter push: (memory floatObjectOf: 42.0).
+	interpreter primitiveStoreFloat64IntoBytes.
+	
+	self deny: interpreter failed.
+	self assert: (memory fetchFloat64: 0 ofObject: array) equals: 42.0.
+
 ]
 
 { #category : #'tests - primitiveAtPut' }


### PR DESCRIPTION
Fixing primitives for Load and Store float64 on arrays.

- [ ] Failing test missing
- [ ] Check JIT compiler primitive